### PR TITLE
adding json support to mysql dialect

### DIFF
--- a/phalcon/db/dialect/mysql.zep
+++ b/phalcon/db/dialect/mysql.zep
@@ -192,6 +192,12 @@ class Mysql extends Dialect
 				}
 				break;
 
+			case Column::TYPE_JSON:
+				if empty columnSql {
+					let columnSql .= "JSON";
+				}
+				break;
+				
 			default:
 				if empty columnSql {
 					throw new Exception("Unrecognized MySQL data type at column " . column->getName());


### PR DESCRIPTION
Hello!

* Type: bug fix / new feature 

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR. - no tests appear to exist for mysql dialect

Small description of change:

adding type_json support for mysql dialect

Thanks

